### PR TITLE
- Android now can use TapTargetSequence listener from Android native lib in react native

### DIFF
--- a/TapTargetViewExample/App.js
+++ b/TapTargetViewExample/App.js
@@ -4,43 +4,79 @@
  * @flow
  */
 
-import React, { Component } from 'react'
-import { Platform, StyleSheet, Text, View, Button } from 'react-native'
+import React, { Component } from 'react';
+import {
+  Platform,
+  StyleSheet,
+  Text,
+  View,
+  Button,
+  DeviceEventEmitter,
+} from 'react-native';
 
 import {
   AppTour,
   AppTourSequence,
-  AppTourView
-} from 'react-native-taptargetview'
+  AppTourView,
+} from 'react-native-taptargetview';
 
-import Top from './components/Top'
-import Center from './components/Center'
-import Bottom from './components/Bottom'
+import Top from './components/Top';
+import Center from './components/Center';
+import Bottom from './components/Bottom';
 
 const instructions = Platform.select({
   ios: 'Press Cmd+R to reload,\n' + 'Cmd+D or shake for dev menu',
   android:
     'Double tap R on your keyboard to reload,\n' +
-    'Shake or press menu button for dev menu'
-})
+    'Shake or press menu button for dev menu',
+});
 
 export default class App extends Component<{}> {
   constructor(props) {
-    super(props)
+    super(props);
 
-    this.appTourTargets = []
+    this.appTourTargets = [];
+  }
+
+  componentWillMount() {
+    this.registerSequenceStepEvent();
+    this.registerFinishSequenceEvent();
   }
 
   componentDidMount() {
     setTimeout(() => {
-      let appTourSequence = new AppTourSequence()
+      let appTourSequence = new AppTourSequence();
       this.appTourTargets.forEach(appTourTarget => {
-        appTourSequence.add(appTourTarget)
-      })
+        appTourSequence.add(appTourTarget);
+      });
 
-      AppTour.ShowSequence(appTourSequence)
-    }, 1000)
+      AppTour.ShowSequence(appTourSequence);
+    }, 1000);
   }
+
+  registerSequenceStepEvent = () => {
+    if (this.sequenceStepListener) {
+      this.sequenceStepListener.remove();
+    }
+    this.sequenceStepListener = DeviceEventEmitter.addListener(
+      'onShowSequenceStepEvent',
+      (e: Event) => {
+        console.log(e);
+      }
+    );
+  };
+
+  registerFinishSequenceEvent = () => {
+    if (this.finishSequenceListener) {
+      this.finishSequenceListener.remove();
+    }
+    this.finishSequenceListener = DeviceEventEmitter.addListener(
+      'onFinishSequenceEvent',
+      (e: Event) => {
+        console.log(e);
+      }
+    );
+  };
 
   render() {
     return (
@@ -48,23 +84,23 @@ export default class App extends Component<{}> {
         <Top
           style={styles.top}
           addAppTourTarget={appTourTarget => {
-            this.appTourTargets.push(appTourTarget)
+            this.appTourTargets.push(appTourTarget);
           }}
         />
         <Center
           style={styles.center}
           addAppTourTarget={appTourTarget => {
-            this.appTourTargets.push(appTourTarget)
+            this.appTourTargets.push(appTourTarget);
           }}
         />
         <Bottom
           style={styles.bottom}
           addAppTourTarget={appTourTarget => {
-            this.appTourTargets.push(appTourTarget)
+            this.appTourTargets.push(appTourTarget);
           }}
         />
       </View>
-    )
+    );
   }
 }
 
@@ -72,15 +108,15 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     flexDirection: 'column',
-    justifyContent: 'space-between'
+    justifyContent: 'space-between',
   },
   top: {
-    flex: 1
+    flex: 1,
   },
   center: {
-    flex: 1
+    flex: 1,
   },
   bottom: {
-    flex: 1
-  }
-})
+    flex: 1,
+  },
+});

--- a/TapTargetViewExample/android/app/build.gradle
+++ b/TapTargetViewExample/android/app/build.gradle
@@ -95,7 +95,7 @@ def enableProguardInReleaseBuilds = false
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.3'
+    buildToolsVersion "25.0.2"
 
     defaultConfig {
         applicationId "com.taptargetviewexample"
@@ -116,6 +116,9 @@ android {
         }
     }
     buildTypes {
+        debug {
+          minifyEnabled false
+        }
         release {
             minifyEnabled enableProguardInReleaseBuilds
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
@@ -139,7 +142,8 @@ android {
 dependencies {
     compile project(':react-native-taptargetview')
     compile fileTree(dir: "libs", include: ["*.jar"])
-    compile "com.android.support:appcompat-v7:25.1.0"
+    compile "com.android.support:appcompat-v7:25.1.1"
+    compile "com.android.support:design:25.1.1"
     compile "com.facebook.react:react-native:+"  // From node_modules
 }
 

--- a/TapTargetViewExample/android/app/build.gradle
+++ b/TapTargetViewExample/android/app/build.gradle
@@ -94,13 +94,13 @@ def enableSeparateBuildPerCPUArchitecture = false
 def enableProguardInReleaseBuilds = false
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 26
+    buildToolsVersion "26.0.2"
 
     defaultConfig {
         applicationId "com.taptargetviewexample"
         minSdkVersion 16
-        targetSdkVersion 25
+        targetSdkVersion 26
         versionCode 1
         versionName "1.0"
         ndk {
@@ -142,8 +142,6 @@ android {
 dependencies {
     compile project(':react-native-taptargetview')
     compile fileTree(dir: "libs", include: ["*.jar"])
-    compile "com.android.support:appcompat-v7:25.1.1"
-    compile "com.android.support:design:25.1.1"
     compile "com.facebook.react:react-native:+"  // From node_modules
 }
 

--- a/TapTargetViewExample/android/build.gradle
+++ b/TapTargetViewExample/android/build.gradle
@@ -3,10 +3,10 @@
 buildscript {
     repositories {
         jcenter()
-        google()
+        maven { url 'https://jitpack.io' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:2.2.3'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -21,6 +21,6 @@ allprojects {
             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
             url "$rootDir/../node_modules/react-native/android"
         }
-        google()
+        maven { url 'https://jitpack.io' }
     }
 }

--- a/TapTargetViewExample/android/build.gradle
+++ b/TapTargetViewExample/android/build.gradle
@@ -22,5 +22,8 @@ allprojects {
             url "$rootDir/../node_modules/react-native/android"
         }
         maven { url 'https://jitpack.io' }
+        maven {
+            url 'https://maven.google.com'
+        }
     }
 }

--- a/TapTargetViewExample/android/gradle.properties
+++ b/TapTargetViewExample/android/gradle.properties
@@ -18,3 +18,4 @@
 # org.gradle.parallel=true
 
 android.useDeprecatedNdk=true
+org.gradle.jvmargs=-Xmx2048M -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8

--- a/TapTargetViewExample/android/gradle/wrapper/gradle-wrapper.properties
+++ b/TapTargetViewExample/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip

--- a/TapTargetViewExample/package.json
+++ b/TapTargetViewExample/package.json
@@ -4,9 +4,13 @@
   "private": true,
   "scripts": {
     "start": "node node_modules/react-native/local-cli/cli.js start",
+    "newclear":
+      "rm -rf $TMPDIR/react-* && watchman watch-del-all && rm -rf ios/build/ModuleCache/* && rm -rf node_modules/ && rm -rf ~/.rncache && yarn install && cd android && ./gradlew clean",
     "test": "jest"
   },
   "dependencies": {
+    "cache": "^2.1.0",
+    "clean": "^4.0.2",
     "react": "16.0.0",
     "react-native": "0.50.3",
     "react-native-taptargetview": "../"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.3.1'
+        classpath 'com.android.tools.build:gradle:2.2.3'
     }
 }
 
@@ -33,5 +33,5 @@ repositories {
 
 dependencies {
     compile 'com.facebook.react:react-native:+'
-    compile 'com.getkeepsafe.taptargetview:taptargetview:1.10.0'
+    compile 'com.github.congnguyen91:TapTargetView:1.11.0-rn2'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -12,12 +12,12 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.3'
+    compileSdkVersion 26
+    buildToolsVersion '26.0.1'
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 25
+        targetSdkVersion 26
         versionCode 1
         versionName "1.0"
     }
@@ -33,5 +33,9 @@ repositories {
 
 dependencies {
     compile 'com.facebook.react:react-native:+'
-    compile 'com.github.congnguyen91:TapTargetView:1.11.0-rn2'
+    compile 'com.android.support:appcompat-v7:26+'
+    compile 'com.android.support:design:26+'
+    //compile 'com.android.support:recyclerview-v7:26+'
+    //compile 'com.android.support:cardview-v7:26+'
+    compile 'com.github.congnguyen91:TapTargetView:1.11.0-rn5'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -35,5 +35,5 @@ dependencies {
     compile 'com.facebook.react:react-native:+'
     compile 'com.android.support:appcompat-v7:26+'
     compile 'com.android.support:design:26+'
-    compile 'com.github.congnguyen91:TapTargetView:1.11.0-rn'
+    compile 'com.github.congnguyen91:TapTargetView:1.11.0-react-native'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -35,5 +35,5 @@ dependencies {
     compile 'com.facebook.react:react-native:+'
     compile 'com.android.support:appcompat-v7:26+'
     compile 'com.android.support:design:26+'
-    compile 'com.github.congnguyen91:TapTargetView:1.11.0-rn5'
+    compile 'com.github.congnguyen91:TapTargetView:1.11.0-rn'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -35,7 +35,5 @@ dependencies {
     compile 'com.facebook.react:react-native:+'
     compile 'com.android.support:appcompat-v7:26+'
     compile 'com.android.support:design:26+'
-    //compile 'com.android.support:recyclerview-v7:26+'
-    //compile 'com.android.support:cardview-v7:26+'
     compile 'com.github.congnguyen91:TapTargetView:1.11.0-rn5'
 }


### PR DESCRIPTION
I want to use listener from TapTargetSequence from official lib android native like: 
```
new TapTargetSequence.Listener() {
        // This listener will tell us when interesting(tm) events happen in regards
        // to the sequence
        @Override
        public void onSequenceFinish() {
            // Yay
        }
        
        @Override
        public void onSequenceStep(TapTarget lastTarget) {
           // Perfom action for the current target
        }

        @Override
        public void onSequenceCanceled(TapTarget lastTarget) {
            // Boo
        }
```
When the latest lib is upgraded into react-native-taptargetview. Two issues happened with:
1. Not support gradle 3.0.0, 3.0.1 with react native now => Fixed by downgrading to 1.11.0 tag
2. Build error with magic missing interface => it takes me more 1 days to debug. 
=> fixed by fork lib with tag-  https://github.com/congnguyen91/TapTargetView/tree/1.11.0-rn2

- I also updated example & tested on device